### PR TITLE
refactor: move plugin setup to config.lua and update internal config usage

### DIFF
--- a/doc/tailwind-autosort.nvim.txt
+++ b/doc/tailwind-autosort.nvim.txt
@@ -1,4 +1,4 @@
-*tailwind-autosort.nvim.txt*       For Neovim       Last change: 2025 March 29
+*tailwind-autosort.nvim.txt*       For Neovim       Last change: 2025 April 10
 
 ==============================================================================
 Table of Contents                   *tailwind-autosort.nvim-table-of-contents*

--- a/lua/tailwind-autosort/cmd.lua
+++ b/lua/tailwind-autosort/cmd.lua
@@ -10,11 +10,10 @@ M.create_augroup = function(name)
 	return augroup("tailwind-autosort_" .. name, { clear = true })
 end
 
----@param config TailwindAutoSort.Config
-M.create_user_command = function(config)
+M.create_user_command = function()
 	usercmd("TailwindAutoSortRun", function()
 		vim.schedule(function()
-			require("tailwind-autosort.lsp").run_sort(config)
+			require("tailwind-autosort.lsp").run_sort()
 		end)
 	end, {})
 
@@ -25,13 +24,12 @@ M.create_user_command = function(config)
 	)
 end
 
----@param config TailwindAutoSort.Config
-M.create_autocmd = function(config)
+M.create_autocmd = function()
 	autocmd("BufWritePre", {
 		group = M.create_augroup("sort_write_pre"),
 		pattern = { "*.tsx", "*.jsx", "*.css" },
 		callback = function()
-			require("tailwind-autosort.lsp").run_sort(config)
+			require("tailwind-autosort.lsp").run_sort()
 		end,
 	})
 end

--- a/lua/tailwind-autosort/config.lua
+++ b/lua/tailwind-autosort/config.lua
@@ -1,7 +1,22 @@
+local M = {}
+
+M.config = {}
+
 ---@type TailwindAutoSort.Config
-local config = {
+local defaults = {
 	enable_autocmd = true,
 	notify_line_changed = true,
 }
 
-return config
+---@param user_config? TailwindAutoSort.Config
+M.setup = function(user_config)
+	M.config = vim.tbl_deep_extend("force", defaults, user_config or {})
+
+	require("tailwind-autosort.cmd").create_user_command()
+
+	if M.config.enable_autocmd then
+		require("tailwind-autosort.cmd").create_autocmd()
+	end
+end
+
+return M

--- a/lua/tailwind-autosort/init.lua
+++ b/lua/tailwind-autosort/init.lua
@@ -8,17 +8,6 @@ local M = {}
 ---@field prettier_root_dir string|nil|false
 ---@field has_tw_prettier_plugin boolean|nil
 
-M.config = require("tailwind-autosort.config")
-
----@param user_config? TailwindAutoSort.Config
-M.setup = function(user_config)
-	M.config = vim.tbl_deep_extend("force", M.config, user_config or {})
-
-	require("tailwind-autosort.cmd").create_user_command(M.config)
-
-	if M.config.enable_autocmd then
-		require("tailwind-autosort.cmd").create_autocmd(M.config)
-	end
-end
+M.setup = require("tailwind-autosort.config").setup
 
 return M

--- a/lua/tailwind-autosort/lsp.lua
+++ b/lua/tailwind-autosort/lsp.lua
@@ -17,8 +17,9 @@ M.get_tw_lsp_client = function()
 	return tw_client
 end
 
----@param config TailwindAutoSort.Config
-M.run_sort = function(config)
+M.run_sort = function()
+	local config = require("tailwind-autosort.config").config
+
 	local done = false
 
 	-- Set prettier root into cache


### PR DESCRIPTION
Internal functions now retrieve the config directly from config.lua
instead of receiving it via parameters. This change is internal and does
not affect the user API.
